### PR TITLE
Speed up unit tests

### DIFF
--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -684,7 +684,6 @@ func TestWatchDNSCertForK8sCA(t *testing.T) {
 			var certRotated bool
 			var rotatedCertBytes []byte
 			err := retry.Until(func() bool {
-				time.Sleep(time.Second)
 				rotatedCertBytes = s.istiodCertBundleWatcher.GetKeyCertBundle().CertPem
 				st := string(rotatedCertBytes)
 				certRotated = st != string(tt.certToWatch)

--- a/pilot/pkg/networking/grpcgen/grpcgen_test.go
+++ b/pilot/pkg/networking/grpcgen/grpcgen_test.go
@@ -501,7 +501,6 @@ func testRBAC(t *testing.T, grpcServer *xdsgrpc.GRPCServer, xdsresolver resolver
 			log.Error(err)
 		}
 	}()
-	time.Sleep(3 * time.Second)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 

--- a/pkg/webhooks/validation/controller/controller_test.go
+++ b/pkg/webhooks/validation/controller/controller_test.go
@@ -286,7 +286,7 @@ func TestBackoff(t *testing.T) {
 // TestUpdateAll ensures that we create request to update all webhooks when CA bundle changes.
 func TestUpdateAll(t *testing.T) {
 	c := createTestController(t)
-	c.queue = workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 1*time.Minute))
+	c.queue = workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(1*time.Millisecond, 1*time.Minute))
 
 	// add two validating webhook configurations
 	const secondName = "second"
@@ -318,7 +318,7 @@ func TestUpdateAll(t *testing.T) {
 			}
 		}
 		return true
-	}, retry.Delay(time.Second), retry.Timeout(time.Second*5))
+	}, retry.Delay(time.Millisecond), retry.Timeout(time.Second*5))
 }
 
 func TestCABundleChange(t *testing.T) {

--- a/samples/tcp-echo/src/main_test.go
+++ b/samples/tcp-echo/src/main_test.go
@@ -35,7 +35,7 @@ func TestTcpEchoServer(t *testing.T) {
 	go main()
 
 	// wait for the TCP Echo Server to start
-	time.Sleep(500*time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	for _, addr := range []string{":9000", ":9001"} {
 		// connect to the TCP Echo Server

--- a/samples/tcp-echo/src/main_test.go
+++ b/samples/tcp-echo/src/main_test.go
@@ -35,7 +35,7 @@ func TestTcpEchoServer(t *testing.T) {
 	go main()
 
 	// wait for the TCP Echo Server to start
-	time.Sleep(2 * time.Second)
+	time.Sleep(500*time.Millisecond)
 
 	for _, addr := range []string{":9000", ":9001"} {
 		// connect to the TCP Echo Server


### PR DESCRIPTION
**Please provide a description of this PR:**

Made the following changes and applied [stress test](https://github.com/istio/istio/wiki/Test-Flakes#reproducing-test-flakes) to all these tests:

- Reduced retry delay from 1s to 1ms for `TestUpdateAll` in `controller_test.go`. Now it's executing in ~0.11s. It is reporting 0 failures in 23585 runs in 15 minutes using stress test.
- Reduced sleep time to 500ms for `TestTcpEchoServer` in `main_test.go`. Now it's executing in ~0.503s. It is reporting 0 failures in 1718 runs in 15 minutes using stress test with `-p 1`.

Eager to have feedback / suggestions.